### PR TITLE
feat: SMTP 구성 변경 (#33)

### DIFF
--- a/src/main/java/com/everyonewaiter/mail/adapter/out/infrastructure/SimpleMailSender.java
+++ b/src/main/java/com/everyonewaiter/mail/adapter/out/infrastructure/SimpleMailSender.java
@@ -2,7 +2,6 @@ package com.everyonewaiter.mail.adapter.out.infrastructure;
 
 import java.nio.charset.StandardCharsets;
 
-import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -17,17 +16,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 class SimpleMailSender implements MailSender {
 
-	private static final String DEFAULT_EMAIL_SENDER = "모두의 웨이터 <%s>";
-
 	private final JavaMailSender javaMailSender;
-	private final MailProperties mailProperties;
 
 	@Override
 	public void sendTo(String recipient, String subject, String content) {
 		try {
 			MimeMessage mimeMessage = javaMailSender.createMimeMessage();
 			MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.name());
-			messageHelper.setFrom(DEFAULT_EMAIL_SENDER.formatted(mailProperties.getUsername()));
+			messageHelper.setFrom("모두의 웨이터 <noreply@everyonewaiter.com>");
 			messageHelper.setTo(recipient);
 			messageHelper.setSubject(subject);
 			messageHelper.setText(content, true);

--- a/src/main/java/com/everyonewaiter/mail/application/domain/service/EmailSendExecutorImpl.java
+++ b/src/main/java/com/everyonewaiter/mail/application/domain/service/EmailSendExecutorImpl.java
@@ -3,7 +3,6 @@ package com.everyonewaiter.mail.application.domain.service;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,17 +21,16 @@ import lombok.RequiredArgsConstructor;
 class EmailSendExecutorImpl implements EmailSendExecutor {
 
 	private final MailHistoryCreatePort mailHistoryCreatePort;
-	private final MailProperties mailProperties;
 	private final MailSender mailSender;
 
 	@Override
 	public void sendTo(EmailSendDetail detail) {
-		Email sender = new Email(mailProperties.getUsername());
-		MailHistory mailHistory = execute(sender, actionSendTo(), detail);
+		MailHistory mailHistory = execute(actionSendTo(), detail);
 		mailHistoryCreatePort.create(mailHistory);
 	}
 
-	private MailHistory execute(Email sender, Consumer<EmailSendDetail> action, EmailSendDetail detail) {
+	private MailHistory execute(Consumer<EmailSendDetail> action, EmailSendDetail detail) {
+		Email sender = detail.sender();
 		List<Email> recipients = detail.recipients();
 		String subject = detail.subject();
 		String content = detail.content();

--- a/src/main/java/com/everyonewaiter/mail/application/port/in/command/EmailSendDetail.java
+++ b/src/main/java/com/everyonewaiter/mail/application/port/in/command/EmailSendDetail.java
@@ -6,6 +6,10 @@ import com.everyonewaiter.user.application.domain.model.Email;
 
 public interface EmailSendDetail {
 
+	String DEFAULT_SENDER_MAIL = "noreply@everyonewaiter.com";
+
+	Email sender();
+
 	List<Email> recipients();
 
 	String subject();

--- a/src/main/java/com/everyonewaiter/mail/application/port/in/command/EmailSendToCommand.java
+++ b/src/main/java/com/everyonewaiter/mail/application/port/in/command/EmailSendToCommand.java
@@ -4,7 +4,16 @@ import java.util.List;
 
 import com.everyonewaiter.user.application.domain.model.Email;
 
-public record EmailSendToCommand(Email recipient, String subject, String content) implements EmailSendDetail {
+public record EmailSendToCommand(
+	Email sender,
+	Email recipient,
+	String subject,
+	String content
+) implements EmailSendDetail {
+
+	public EmailSendToCommand(Email recipient, String subject, String content) {
+		this(new Email(DEFAULT_SENDER_MAIL), recipient, subject, content);
+	}
 
 	@Override
 	public List<Email> recipients() {

--- a/src/main/java/com/everyonewaiter/message/application/domain/service/AlimTalkSendExecutorImpl.java
+++ b/src/main/java/com/everyonewaiter/message/application/domain/service/AlimTalkSendExecutorImpl.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,21 +26,20 @@ import lombok.RequiredArgsConstructor;
 class AlimTalkSendExecutorImpl implements AlimTalkSendExecutor {
 
 	private final AlimTalkSender alimTalkSender;
-	private final MailProperties mailProperties;
 	private final MessageHistoryCreatePort messageHistoryCreatePort;
 
 	@Override
-	public void sendTo(AlimTalkSendDetail command) {
-		Email sender = new Email(mailProperties.getUsername());
-		List<MessageHistory> messageHistories = execute(sender, actionSendTo(), command);
+	public void sendTo(AlimTalkSendDetail detail) {
+		List<MessageHistory> messageHistories = execute(actionSendTo(), detail);
 		messageHistoryCreatePort.create(messageHistories);
 	}
 
-	private List<MessageHistory> execute(Email sender, Consumer<AlimTalkSendDetail> action, AlimTalkSendDetail detail) {
+	private List<MessageHistory> execute(Consumer<AlimTalkSendDetail> action, AlimTalkSendDetail detail) {
+		Email sender = detail.sender();
 		String templateCode = detail.templateCode();
 		List<AlimTalkMessage> messages = detail.messages();
-		List<MessageHistory> messageHistories = new ArrayList<>();
 
+		List<MessageHistory> messageHistories = new ArrayList<>();
 		try {
 			action.accept(detail);
 			messages.forEach(message -> messageHistories.add(createSuccessHistory(sender, message, templateCode)));

--- a/src/main/java/com/everyonewaiter/message/application/port/in/AlimTalkSendExecutor.java
+++ b/src/main/java/com/everyonewaiter/message/application/port/in/AlimTalkSendExecutor.java
@@ -4,5 +4,5 @@ import com.everyonewaiter.message.application.port.in.command.AlimTalkSendDetail
 
 public interface AlimTalkSendExecutor {
 
-	void sendTo(AlimTalkSendDetail command);
+	void sendTo(AlimTalkSendDetail detail);
 }

--- a/src/main/java/com/everyonewaiter/message/application/port/in/command/AlimTalkSendDetail.java
+++ b/src/main/java/com/everyonewaiter/message/application/port/in/command/AlimTalkSendDetail.java
@@ -3,8 +3,13 @@ package com.everyonewaiter.message.application.port.in.command;
 import java.util.List;
 
 import com.everyonewaiter.message.application.domain.model.AlimTalkMessage;
+import com.everyonewaiter.user.application.domain.model.Email;
 
 public interface AlimTalkSendDetail {
+
+	String DEFAULT_SENDER_MAIL = "noreply@everyonewaiter.com";
+
+	Email sender();
 
 	String templateCode();
 

--- a/src/main/java/com/everyonewaiter/message/application/port/in/command/AlimTalkSendToCommand.java
+++ b/src/main/java/com/everyonewaiter/message/application/port/in/command/AlimTalkSendToCommand.java
@@ -3,8 +3,17 @@ package com.everyonewaiter.message.application.port.in.command;
 import java.util.List;
 
 import com.everyonewaiter.message.application.domain.model.AlimTalkMessage;
+import com.everyonewaiter.user.application.domain.model.Email;
 
-public record AlimTalkSendToCommand(String templateCode, AlimTalkMessage message) implements AlimTalkSendDetail {
+public record AlimTalkSendToCommand(
+	Email sender,
+	String templateCode,
+	AlimTalkMessage message
+) implements AlimTalkSendDetail {
+
+	public AlimTalkSendToCommand(String templateCode, AlimTalkMessage message) {
+		this(new Email(DEFAULT_SENDER_MAIL), templateCode, message);
+	}
 
 	@Override
 	public List<AlimTalkMessage> messages() {

--- a/src/test/java/com/everyonewaiter/fixture/mail/EmailSendDetailBuilder.java
+++ b/src/test/java/com/everyonewaiter/fixture/mail/EmailSendDetailBuilder.java
@@ -8,12 +8,18 @@ import com.everyonewaiter.user.application.domain.model.Email;
 
 public class EmailSendDetailBuilder {
 
+	private final Email sender = new EmailBuilder().build();
 	private final List<Email> recipients = List.of(new EmailBuilder().build());
 	private final String subject = "SUBJECT";
 	private final String content = "CONTENT";
 
 	public EmailSendDetail build() {
 		return new EmailSendDetail() {
+
+			@Override
+			public Email sender() {
+				return sender;
+			}
 
 			@Override
 			public List<Email> recipients() {

--- a/src/test/java/com/everyonewaiter/fixture/message/AlimTalkSendDetailBuilder.java
+++ b/src/test/java/com/everyonewaiter/fixture/message/AlimTalkSendDetailBuilder.java
@@ -3,11 +3,14 @@ package com.everyonewaiter.fixture.message;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.everyonewaiter.fixture.user.EmailBuilder;
 import com.everyonewaiter.message.application.domain.model.AlimTalkMessage;
 import com.everyonewaiter.message.application.port.in.command.AlimTalkSendDetail;
+import com.everyonewaiter.user.application.domain.model.Email;
 
 public class AlimTalkSendDetailBuilder {
 
+	private final Email sender = new EmailBuilder().build();
 	private final List<AlimTalkMessage> messages = new ArrayList<>();
 	private final String templateCode = "TEMPLATE_CODE";
 
@@ -22,6 +25,11 @@ public class AlimTalkSendDetailBuilder {
 
 	public AlimTalkSendDetail build() {
 		return new AlimTalkSendDetail() {
+
+			@Override
+			public Email sender() {
+				return sender;
+			}
 
 			@Override
 			public String templateCode() {

--- a/src/test/java/com/everyonewaiter/mail/application/domain/service/EmailSendExecutorImplTest.java
+++ b/src/test/java/com/everyonewaiter/mail/application/domain/service/EmailSendExecutorImplTest.java
@@ -3,7 +3,6 @@ package com.everyonewaiter.mail.application.domain.service;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 import static org.mockito.Mockito.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,10 +10,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.autoconfigure.mail.MailProperties;
 
 import com.everyonewaiter.fixture.mail.EmailSendDetailBuilder;
-import com.everyonewaiter.fixture.user.EmailBuilder;
 import com.everyonewaiter.mail.application.domain.model.MailHistory;
 import com.everyonewaiter.mail.application.domain.model.MailHistoryStatus;
 import com.everyonewaiter.mail.application.port.in.command.EmailSendDetail;
@@ -28,18 +25,10 @@ class EmailSendExecutorImplTest {
 	MailHistoryCreatePort mailHistoryCreatePort;
 
 	@Mock
-	MailProperties mailProperties;
-
-	@Mock
 	MailSender mailSender;
 
 	@InjectMocks
 	EmailSendExecutorImpl emailSendExecutor;
-
-	@BeforeEach
-	void setUp() {
-		when(mailProperties.getUsername()).thenReturn(new EmailBuilder().build().value());
-	}
 
 	@DisplayName("메일 발송에 성공하면 메일 히스토리의 상태는 SUCCESS이다.")
 	@Test

--- a/src/test/java/com/everyonewaiter/message/application/domain/service/AlimTalkSendExecutorImplTest.java
+++ b/src/test/java/com/everyonewaiter/message/application/domain/service/AlimTalkSendExecutorImplTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,10 +14,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.autoconfigure.mail.MailProperties;
 
 import com.everyonewaiter.fixture.message.AlimTalkSendDetailBuilder;
-import com.everyonewaiter.fixture.user.EmailBuilder;
 import com.everyonewaiter.message.application.domain.model.MessageHistory;
 import com.everyonewaiter.message.application.domain.model.MessageHistoryStatus;
 import com.everyonewaiter.message.application.port.in.command.AlimTalkSendDetail;
@@ -32,9 +29,6 @@ class AlimTalkSendExecutorImplTest {
 	AlimTalkSender alimTalkSender;
 
 	@Mock
-	MailProperties mailProperties;
-
-	@Mock
 	MessageHistoryCreatePort messageHistoryCreatePort;
 
 	@InjectMocks
@@ -42,11 +36,6 @@ class AlimTalkSendExecutorImplTest {
 
 	@Captor
 	ArgumentCaptor<List<MessageHistory>> captor;
-
-	@BeforeEach
-	void setUp() {
-		when(mailProperties.getUsername()).thenReturn(new EmailBuilder().build().value());
-	}
 
 	@DisplayName("알림톡 발송에 성공하면 메시지 히스토리의 상태는 SUCCESS이다.")
 	@Test


### PR DESCRIPTION
## 연관 이슈

- [x] #33 

## 작업 내용

SMTP 구성 변경으로 인해 MailProperties의 username 값을 히스토리의 sender 값으로 사용하지 못하게 되어 sender를 직접 명시하여 사용하도록 변경하였습니다.

### 스크린샷 (선택)

## 참고 사항
